### PR TITLE
Add support for loading environment variables from a config file in runner.py

### DIFF
--- a/t/lib/config.env
+++ b/t/lib/config.env
@@ -31,3 +31,6 @@ export EDGE_SPOCK="3.3"
 #export EDGE_REPSET="demo-repset"
 
 export EDGE_CLI="pgedge"
+
+# Path to store autoddl related actual outputs
+export EDGE_ACTUAL_OUT_DIR="/tmp/auto_ddl/"


### PR DESCRIPTION
Enhanced runner to support loading environment variables from a config file:

- Added `-c` / `--config` option for specifying a config file.
- Implemented `source_config_file` to read (from a bash friendly file) and set environment variables. In debug mode, prints variables starting with EDGE.
- Moved global variable initialization to `initialize_pg_config` to set values after sourcing the config file.
- Maintained support for manually sourcing the config file before running the script.

Also introduced a new config variables so that the actual output directory for autoDDL tests can be configured.