### PR TITLE
Added support for configurable spock version 

### DIFF
--- a/t/8000a_env_setup_pgedge_node1.pl
+++ b/t/8000a_env_setup_pgedge_node1.pl
@@ -22,9 +22,6 @@ my $homedir1 = "$n1dir/pgedge";
 my $ncdir = "$ENV{NC_DIR}";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
-my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 my $skipInstall = 0;
 my $ncdir_copy = "/tmp/nccopy";

--- a/t/8000b_install_pgedge_node1.pl
+++ b/t/8000b_install_pgedge_node1.pl
@@ -18,20 +18,37 @@ my $homedir1 = "$n1dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
 my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
+my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
+
+# Construct the CLI setup base command, keeping spock default (no spock version specified)
+my $setup_command = qq(./$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT} --pg_ver $ENV{EDGE_INST_VERSION});
+
+# Append the --spock_ver argument if the version type is pinned
+if ($ver_type eq 'pinned') {
+    $setup_command .= qq( --spock_ver $spock_ver);
+}
+
 # Install pgedge
-print("Install pgedge\n");
+print("pgedge setup command :  $setup_command \n");
 chdir("./$homedir1");
-my $out_buf = (run_command_and_exit_iferr(qq(./$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT} --pg_ver $ENV{EDGE_INST_VERSION})))[3];
+# Run the CLI setup command
+my $out_buf = (run_command_and_exit_iferr($setup_command))[3];
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
     $exitcode = 0;
 }
+
+print "Setup command output: @$out_buf\n";
 
 #check for pgV
 my $cmd = qq(./$cli um list);

--- a/t/8001a_env_setup_pgedge_node2.pl
+++ b/t/8001a_env_setup_pgedge_node2.pl
@@ -22,9 +22,6 @@ my $homedir2 = "$n2dir/pgedge";
 my $ncdir = "$ENV{NC_DIR}";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
-my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 my $skipInstall = 0;
 my $ncdir_copy = "/tmp/nccopy";

--- a/t/8001b_install_pgedge_node2.pl
+++ b/t/8001b_install_pgedge_node2.pl
@@ -17,21 +17,39 @@ my $n2dir = "$ENV{EDGE_CLUSTER_DIR}/n2";
 my $homedir2 = "$n2dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
-my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $snowflakeversion = "snowflake-$pgversion";
+
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
+my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
+
+# Construct the CLI setup base command, keeping spock default (no spock version specified)
+my $setup_command = qq($homedir2/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg_ver $ENV{EDGE_INST_VERSION});
+
+# Append the --spock_ver argument if the version type is pinned
+if ($ver_type eq 'pinned') {
+    $setup_command .= qq( --spock_ver $spock_ver);
+}
 
 # Install pgedge
-print("Install pgedge");
-my $out_buf = (run_command_and_exit_iferr(qq($homedir2/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg_ver $ENV{EDGE_INST_VERSION})))[3];
+print("pgedge setup command :  $setup_command \n");
+# Run the CLI setup command
+my $out_buf = (run_command_and_exit_iferr($setup_command))[3];
+
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
     $exitcode = 0;
 }
+
+print "Setup command output: @$out_buf\n";
 
 #check for pgV
 my $cmd = qq($homedir2/$cli um list);

--- a/t/8002a_env_setup_pgedge_node3.pl
+++ b/t/8002a_env_setup_pgedge_node3.pl
@@ -22,9 +22,6 @@ my $homedir3 = "$n3dir/pgedge";
 my $ncdir = "$ENV{NC_DIR}";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
-my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 my $skipInstall = 0;
 my $ncdir_copy = "/tmp/nccopy";

--- a/t/8002b_install_pgedge_node3.pl
+++ b/t/8002b_install_pgedge_node3.pl
@@ -17,21 +17,38 @@ my $n3dir = "$ENV{EDGE_CLUSTER_DIR}/n3";
 my $homedir3 = "$n3dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
-my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
-my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
 my $myport3 = $ENV{'EDGE_START_PORT'} + 2;
+my $snowflakeversion = "snowflake-$pgversion";
+
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
+my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
+
+# Construct the CLI setup base command, keeping spock default (no spock version specified)
+my $setup_command = qq($homedir3/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport3 --pg_ver $ENV{EDGE_INST_VERSION});
+
+# Append the --spock_ver argument if the version type is pinned
+if ($ver_type eq 'pinned') {
+    $setup_command .= qq( --spock_ver $spock_ver);
+}
 
 # Install pgedge
-print("Install pgedge");
-my $out_buf = (run_command_and_exit_iferr(qq($homedir3/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport3 --pg_ver $ENV{EDGE_INST_VERSION})))[3];
+print("pgedge setup command :  $setup_command \n");
+# Run the CLI setup command
+my $out_buf = (run_command_and_exit_iferr($setup_command))[3];
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
     $exitcode = 0;
 }
+
+print "Setup command output: @$out_buf\n";
 
 #check for pgV
 my $cmd = qq($homedir3/$cli um list);

--- a/t/8998_env_remove_pgedge_node1.pl
+++ b/t/8998_env_remove_pgedge_node1.pl
@@ -22,7 +22,12 @@ my $homedir1 = "$n1dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
 my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
 my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $datadir1="$homedir1/data/$pgversion";
 #my $pgpassEntry = "*:*:*:$username:$password";
@@ -33,7 +38,7 @@ my $exitcode = 0;
 print("Removing pgedge on node 1\n");
 run_command_and_exit_iferr(qq($homedir1/$cli remove $pgversion --rm-data));
 #run_command_and_exit_iferr(qq($homedir1/$cli remove pgedge --pg $ENV{EDGE_INST_VERSION}));
-print("Verifying $pgversion , $spver , $spver are removed from node 1\n");
+print("Verifying $pgversion , $spockversion  , $snowflakeversion are removed from node 1\n");
 #check for pgV
 my $cmd = qq($homedir1/$cli um list);
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= run_command($cmd);

--- a/t/8999_env_remove_pgedge_node2.pl
+++ b/t/8999_env_remove_pgedge_node2.pl
@@ -22,7 +22,12 @@ my $homedir2 = "$n2dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
 my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
 my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $datadir2="$homedir2/data/$pgversion";
 #my $pgpassEntry = "*:*:*:$username:$password";
@@ -32,7 +37,7 @@ my $exitcode = 0;
 # Remove pgedge
 print("Removing pgedge on node 2\n");
 run_command_and_exit_iferr(qq($homedir2/$cli remove $pgversion --rm-data));
-print("Verifying $pgversion , $spver , $spver are removed from node 2\n");
+print("Verifying $pgversion , $spockversion , $snowflakeversion are removed from node 2\n");
 #check for pgV
 my $cmd = qq($homedir2/$cli um list);
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= run_command($cmd);

--- a/t/8999b_env_remove_pgedge_node3.pl
+++ b/t/8999b_env_remove_pgedge_node3.pl
@@ -22,7 +22,12 @@ my $homedir3 = "$n3dir/pgedge";
 my $cli = "$ENV{EDGE_CLI}";
 my $pgversion = "$ENV{EDGE_COMPONENT}";
 my $snowflakeversion = "snowflake-$pgversion";
-my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
+# Fetch the spock version from the configuration
+my ($spock_ver, $ver_type) = get_spock_ver_from_config();
+# Remove dots and extract the first two characters to form spock product name
+my $spver = $spock_ver;
+$spver =~ s/\.//g;
+$spver = substr($spver, 0, 2);
 my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $datadir3="$homedir3/data/$pgversion";
 #my $pgpassEntry = "*:*:*:$username:$password";
@@ -31,7 +36,7 @@ my $exitcode = 0;
 # Remove pgedge
 print("Removing pgedge on node 3\n");
 run_command_and_exit_iferr(qq($homedir3/$cli remove $pgversion --rm-data));
-print("Verifying $pgversion , $spver , $spver are removed from node 3\n");
+print("Verifying $pgversion , $spockversion , $snowflakeversion are removed from node 3\n");
 #check for pgV
 my $cmd = qq($homedir3/$cli um list);
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= run_command($cmd);

--- a/t/lib/config.env
+++ b/t/lib/config.env
@@ -19,16 +19,20 @@ export EDGE_HOME_DIR="$NC_DIR/pgedge"
 export EDGE_CLUSTER="demo"
 export EDGE_CLUSTER_DIR="$EDGE_HOME_DIR/cluster/$EDGE_CLUSTER"
 
-# These are the properties associated with the setup:
-
+# These are the arguments associated with the cli setup:
 export EDGE_USERNAME="lcusr"
 export EDGE_PASSWORD="password"
 export EDGE_DB="lcdb"
 export EDGE_REPUSER=`whoami`
+
+# postgres version details
 export EDGE_INST_VERSION=16
 export EDGE_COMPONENT="pg$EDGE_INST_VERSION"
-export EDGE_SPOCK="3.3"
-#export EDGE_REPSET="demo-repset"
+
+# spock version to install, if pinned_ver has a value, it will be prioritised over default_ver
+# keep pinned_ver empty if you want to use spocks default version 
+export EDGE_SPOCK_DEFAULT_VER="3.3"
+export EDGE_SPOCK_PINNED_VER="4.0beta1-1"
 
 export EDGE_CLI="pgedge"
 

--- a/t/lib/contains.pm
+++ b/t/lib/contains.pm
@@ -167,6 +167,24 @@ sub sanitize_and_combine_multiline_stdout {
     return $str;
 }
 
+# This function reads the EDGE_SPOCK_DEFAULT_VER and EDGE_SPOCK_PINNED_VER
+# environment variables. If EDGE_SPOCK_PINNED_VER is defined and not empty,
+# it returns this version along with the version type 'pinned'. Otherwise, it
+# returns EDGE_SPOCK_DEFAULT_VER along with the version type 'default'.
+
+sub get_spock_ver_from_config {
+    my $default_ver = $ENV{EDGE_SPOCK_DEFAULT_VER} // '';
+    my $pinned_ver = $ENV{EDGE_SPOCK_PINNED_VER} // '';
+    
+    print("EDGE_SPOCK_DEFAULT_VER is $default_ver and EDGE_SPOCK_PINNED_VER is $pinned_ver .\n");
+    
+    if ($pinned_ver ne '') {
+        return ($pinned_ver, 'pinned');
+    } else {
+        return ($default_ver, 'default');
+    }
+}
+
 
 # This 1 at the end is required, even though it looks like an accident :)
 1;


### PR DESCRIPTION
Configurable spock version can now be passed to the setup command based on how its defined in the config file:
- Renamed environment variable EDGE_SPOCK to EDGE_SPOCK_DEFAULT_VER.
- Introduced EDGE_SPOCK_PINNED_VER to specify a pinned Spock version.
- Implemented get_spock_ver_from_config function in contains.pm to read the appropriate Spock versions (pinned or default) from the configuration.
- Modified 8001, 8002, 8003 scripts to conditionally include --spock_ver argument in the CLI setup command if the pinned version is specified (otherwise use the default).
- Incorporated changes in the 8998, 8999, 8999b cleanup scripts.