### PR TITLE
autoddl tests for list and hash partitioning

### DIFF
--- a/schedule_files/auto_ddl_schedule
+++ b/schedule_files/auto_ddl_schedule
@@ -33,6 +33,12 @@ t/auto_ddl/6111c_table_validate_n1.sql
 t/auto_ddl/6122a_table_range_partitions_n1.sql
 t/auto_ddl/6122b_table_range_partitions_validate_n2.sql
 t/auto_ddl/6122c_table_range_parition_validate_n1.sql
+t/auto_ddl/6133a_table_list_partitions_n1.sql
+t/auto_ddl/6133b_table_list_partitions_validate_n2.sql
+t/auto_ddl/6133c_table_list_parition_validate_n1.sql
+t/auto_ddl/6144a_table_hash_partitions_n1.sql
+t/auto_ddl/6144b_table_hash_partitions_validate_n2.sql
+t/auto_ddl/6144c_table_hash_parition_validate_n1.sql
 ##
 # cleanup scripts
 ##

--- a/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.out
+++ b/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.out
@@ -382,6 +382,11 @@ EXPLAIN ANALYZE CREATE TABLE table_ctas6 AS
 SELECT 1 AS a;
 INFO:  DDL statement replicated.
 \o
+/*
+TO FIX: 
+At present, no repset is assigned for table created through EXPLAIN ANALYZE
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=65421352
+*/
 -- Validate table_ctas6
 \d table_ctas6
             Table "public.table_ctas6"

--- a/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.sql
+++ b/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.sql
@@ -175,7 +175,11 @@ EXECUTE spocktab('table_ctas5'); -- should be in default_insert_only set
 EXPLAIN ANALYZE CREATE TABLE table_ctas6 AS
 SELECT 1 AS a;
 \o
-
+/*
+TO FIX: 
+At present, no repset is assigned for table created through EXPLAIN ANALYZE
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=65421352
+*/
 -- Validate table_ctas6
 \d table_ctas6
 EXECUTE spocktab('table_ctas6'); -- should be in default_insert_only set

--- a/t/auto_ddl/6122a_table_range_partitions_n1.out
+++ b/t/auto_ddl/6122a_table_range_partitions_n1.out
@@ -126,7 +126,12 @@ Indexes:
     "revenue_range_pkey" PRIMARY KEY, btree (rev_id, rev_date)
 Number of partitions: 2 (Use \d+ to list them.)
 
-EXECUTE spocktab('revenue_range'); -- Expect revenue_range to move to default set
+/*TO FIX:
+At present, adding a parimary key to parent table does not move the partitions to default repset.
+To revisit and update outputs once this is addressed
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+*/
+EXECUTE spocktab('revenue_range'); -- Expect revenue_range and all child partitions to move to default set
  nspname |      relname       |      set_name       
 ---------+--------------------+---------------------
  public  | revenue_range      | default

--- a/t/auto_ddl/6122a_table_range_partitions_n1.sql
+++ b/t/auto_ddl/6122a_table_range_partitions_n1.sql
@@ -61,7 +61,12 @@ EXECUTE spocktab('sales_range'); -- Expect sales_range_2023 in default set
 -- Add a primary key to a range partitioned table that initially didn't have one
 ALTER TABLE revenue_range ADD PRIMARY KEY (rev_id, rev_date);
 \d revenue_range
-EXECUTE spocktab('revenue_range'); -- Expect revenue_range to move to default set
+/*TO FIX:
+At present, adding a parimary key to parent table does not move the partitions to default repset.
+To revisit and update outputs once this is addressed
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+*/
+EXECUTE spocktab('revenue_range'); -- Expect revenue_range and all child partitions to move to default set
 
 -- Add another partition to the modified table
 CREATE TABLE revenue_range_2023 PARTITION OF revenue_range

--- a/t/auto_ddl/6133a_table_list_partitions_n1.out
+++ b/t/auto_ddl/6133a_table_list_partitions_n1.out
@@ -1,0 +1,163 @@
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+-----------------------------
+-- List Partitioning Examples
+-----------------------------
+-- Create a list partitioned table with primary key
+CREATE TABLE sales_list (
+    sale_id INT,
+    sale_region TEXT,
+    sale_amount DECIMAL,
+    PRIMARY KEY (sale_id, sale_region)
+) PARTITION BY LIST (sale_region);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Add partitions to the sales_list table
+CREATE TABLE sales_list_east PARTITION OF sales_list
+    FOR VALUES IN ('East');
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE sales_list_west PARTITION OF sales_list
+    FOR VALUES IN ('West');
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert data into the sales_list table
+INSERT INTO sales_list (sale_id, sale_region, sale_amount) VALUES
+(1, 'East', 100.0),
+(2, 'West', 200.0),
+(3, 'East', 150.0);
+INSERT 0 3
+EXECUTE spocktab('sales_list'); -- Expect both parent and child tables in default repset
+ nspname |     relname     | set_name 
+---------+-----------------+----------
+ public  | sales_list      | default
+ public  | sales_list_east | default
+ public  | sales_list_west | default
+(3 rows)
+
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 3 rows
+ sale_id | sale_region | sale_amount 
+---------+-------------+-------------
+       1 | East        |       100.0
+       2 | West        |       200.0
+       3 | East        |       150.0
+(3 rows)
+
+-- Alter the sales_list table to add a new partition
+CREATE TABLE sales_list_north PARTITION OF sales_list
+    FOR VALUES IN ('North');
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert data into the new partition
+INSERT INTO sales_list (sale_id, sale_region, sale_amount) VALUES
+(4, 'North', 250.0);
+INSERT 0 1
+-- Validate structure and data after adding new partition
+\d+ sales_list_east
+                                        Table "public.sales_list_east"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('East')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'East'::text))
+Indexes:
+    "sales_list_east_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list_west
+                                        Table "public.sales_list_west"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('West')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'West'::text))
+Indexes:
+    "sales_list_west_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list_north
+                                       Table "public.sales_list_north"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('North')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'North'::text))
+Indexes:
+    "sales_list_north_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list
+                                    Partitioned table "public.sales_list"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition key: LIST (sale_region)
+Indexes:
+    "sales_list_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Partitions: sales_list_east FOR VALUES IN ('East'),
+            sales_list_north FOR VALUES IN ('North'),
+            sales_list_west FOR VALUES IN ('West')
+
+EXECUTE spocktab('sales_list'); -- Expect the new partition to be listed
+ nspname |     relname      | set_name 
+---------+------------------+----------
+ public  | sales_list       | default
+ public  | sales_list_east  | default
+ public  | sales_list_west  | default
+ public  | sales_list_north | default
+(4 rows)
+
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 4 rows
+ sale_id | sale_region | sale_amount 
+---------+-------------+-------------
+       1 | East        |       100.0
+       2 | West        |       200.0
+       3 | East        |       150.0
+       4 | North       |       250.0
+(4 rows)
+
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+-- Create a list partitioned table without primary key
+CREATE TABLE products_list (
+    product_id INT,
+    product_category TEXT,
+    product_name TEXT
+) PARTITION BY LIST (product_category);
+
+-- Add partitions to the products_list table
+CREATE TABLE products_list_electronics PARTITION OF products_list
+    FOR VALUES IN ('Electronics');
+CREATE TABLE products_list_clothing PARTITION OF products_list
+    FOR VALUES IN ('Clothing');
+
+-- Insert data into the products_list table
+INSERT INTO products_list (product_id, product_category, product_name) VALUES
+(1, 'Electronics', 'Laptop'),
+(2, 'Clothing', 'Shirt'),
+(3, 'Electronics', 'Smartphone');
+
+-- Validate structure and data
+\d+ products_list
+EXECUTE spocktab('products_list'); -- Expect both parent and child tables in default_insert_only set
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+
+-- Alter the products_list table to add a primary key
+ALTER TABLE products_list ADD PRIMARY KEY (product_id, product_category);
+
+-- Validate structure and data after adding primary key
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+EXECUTE spocktab('products_list'); -- Expect the replication set to change to default
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+*/

--- a/t/auto_ddl/6133a_table_list_partitions_n1.sql
+++ b/t/auto_ddl/6133a_table_list_partitions_n1.sql
@@ -1,0 +1,81 @@
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+-----------------------------
+-- List Partitioning Examples
+-----------------------------
+
+-- Create a list partitioned table with primary key
+CREATE TABLE sales_list (
+    sale_id INT,
+    sale_region TEXT,
+    sale_amount DECIMAL,
+    PRIMARY KEY (sale_id, sale_region)
+) PARTITION BY LIST (sale_region);
+
+-- Add partitions to the sales_list table
+CREATE TABLE sales_list_east PARTITION OF sales_list
+    FOR VALUES IN ('East');
+CREATE TABLE sales_list_west PARTITION OF sales_list
+    FOR VALUES IN ('West');
+
+-- Insert data into the sales_list table
+INSERT INTO sales_list (sale_id, sale_region, sale_amount) VALUES
+(1, 'East', 100.0),
+(2, 'West', 200.0),
+(3, 'East', 150.0);
+
+EXECUTE spocktab('sales_list'); -- Expect both parent and child tables in default repset
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 3 rows
+
+-- Alter the sales_list table to add a new partition
+CREATE TABLE sales_list_north PARTITION OF sales_list
+    FOR VALUES IN ('North');
+
+-- Insert data into the new partition
+INSERT INTO sales_list (sale_id, sale_region, sale_amount) VALUES
+(4, 'North', 250.0);
+
+-- Validate structure and data after adding new partition
+\d+ sales_list_east
+\d+ sales_list_west
+\d+ sales_list_north
+\d+ sales_list
+EXECUTE spocktab('sales_list'); -- Expect the new partition to be listed
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 4 rows
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+-- Create a list partitioned table without primary key
+CREATE TABLE products_list (
+    product_id INT,
+    product_category TEXT,
+    product_name TEXT
+) PARTITION BY LIST (product_category);
+
+-- Add partitions to the products_list table
+CREATE TABLE products_list_electronics PARTITION OF products_list
+    FOR VALUES IN ('Electronics');
+CREATE TABLE products_list_clothing PARTITION OF products_list
+    FOR VALUES IN ('Clothing');
+
+-- Insert data into the products_list table
+INSERT INTO products_list (product_id, product_category, product_name) VALUES
+(1, 'Electronics', 'Laptop'),
+(2, 'Clothing', 'Shirt'),
+(3, 'Electronics', 'Smartphone');
+
+-- Validate structure and data
+\d+ products_list
+EXECUTE spocktab('products_list'); -- Expect both parent and child tables in default_insert_only set
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+
+-- Alter the products_list table to add a primary key
+ALTER TABLE products_list ADD PRIMARY KEY (product_id, product_category);
+
+-- Validate structure and data after adding primary key
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+EXECUTE spocktab('products_list'); -- Expect the replication set to change to default
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+*/

--- a/t/auto_ddl/6133b_table_list_partitions_validate_n2.out
+++ b/t/auto_ddl/6133b_table_list_partitions_validate_n2.out
@@ -1,0 +1,93 @@
+--This file will run on n2 and validate all the replicated tables data, structure and replication sets they're in
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+\d+ sales_list_east
+                                        Table "public.sales_list_east"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('East')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'East'::text))
+Indexes:
+    "sales_list_east_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list_west
+                                        Table "public.sales_list_west"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('West')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'West'::text))
+Indexes:
+    "sales_list_west_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list_north
+                                       Table "public.sales_list_north"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition of: sales_list FOR VALUES IN ('North')
+Partition constraint: ((sale_region IS NOT NULL) AND (sale_region = 'North'::text))
+Indexes:
+    "sales_list_north_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Access method: heap
+
+\d+ sales_list
+                                    Partitioned table "public.sales_list"
+   Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ sale_id     | integer |           | not null |         | plain    |             |              | 
+ sale_region | text    |           | not null |         | extended |             |              | 
+ sale_amount | numeric |           |          |         | main     |             |              | 
+Partition key: LIST (sale_region)
+Indexes:
+    "sales_list_pkey" PRIMARY KEY, btree (sale_id, sale_region)
+Partitions: sales_list_east FOR VALUES IN ('East'),
+            sales_list_north FOR VALUES IN ('North'),
+            sales_list_west FOR VALUES IN ('West')
+
+EXECUTE spocktab('sales_list'); -- Expect the new partition to be listed
+ nspname |     relname      | set_name 
+---------+------------------+----------
+ public  | sales_list       | default
+ public  | sales_list_east  | default
+ public  | sales_list_west  | default
+ public  | sales_list_north | default
+(4 rows)
+
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 4 rows
+ sale_id | sale_region | sale_amount 
+---------+-------------+-------------
+       1 | East        |       100.0
+       2 | West        |       200.0
+       3 | East        |       150.0
+       4 | North       |       250.0
+(4 rows)
+
+--exercise ddl on n2
+DROP TABLE sales_list CASCADE;
+NOTICE:  drop cascades to table sales_list_north membership in replication set default
+NOTICE:  drop cascades to table sales_list_west membership in replication set default
+NOTICE:  drop cascades to table sales_list_east membership in replication set default
+NOTICE:  drop cascades to table sales_list membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+/*
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+EXECUTE spocktab('products_list'); -- Expect all to be in default repset
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+--exercise ddl on n2
+DROP TABLE products_list CASCADE;
+*/

--- a/t/auto_ddl/6133b_table_list_partitions_validate_n2.sql
+++ b/t/auto_ddl/6133b_table_list_partitions_validate_n2.sql
@@ -1,0 +1,22 @@
+--This file will run on n2 and validate all the replicated tables data, structure and replication sets they're in
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+\d+ sales_list_east
+\d+ sales_list_west
+\d+ sales_list_north
+\d+ sales_list
+EXECUTE spocktab('sales_list'); -- Expect the new partition to be listed
+SELECT * FROM sales_list ORDER BY sale_id; -- Expect 4 rows
+--exercise ddl on n2
+DROP TABLE sales_list CASCADE;
+/*
+https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+EXECUTE spocktab('products_list'); -- Expect all to be in default repset
+SELECT * FROM products_list ORDER BY product_id; -- Expect 3 rows
+--exercise ddl on n2
+DROP TABLE products_list CASCADE;
+*/

--- a/t/auto_ddl/6133c_table_list_parition_validate_n1.out
+++ b/t/auto_ddl/6133c_table_list_parition_validate_n1.out
@@ -1,0 +1,22 @@
+-- This file runs on n1 again to see all the table and their partitions have been dropped on n1 (as a result of drop statements)
+-- being auto replicated via 6133b
+--spock.tables should be empty
+SELECT * FROM spock.tables ORDER BY relid;
+ relid | nspname | relname | set_name 
+-------+---------+---------+----------
+(0 rows)
+
+-- none of these tables should exist.
+\d sales_list_east
+Did not find any relation named "sales_list_east".
+\d sales_list_west
+Did not find any relation named "sales_list_west".
+\d sales_list_north
+Did not find any relation named "sales_list_north".
+\d sales_list
+Did not find any relation named "sales_list".
+/*
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+*/

--- a/t/auto_ddl/6133c_table_list_parition_validate_n1.sql
+++ b/t/auto_ddl/6133c_table_list_parition_validate_n1.sql
@@ -1,0 +1,16 @@
+-- This file runs on n1 again to see all the table and their partitions have been dropped on n1 (as a result of drop statements)
+-- being auto replicated via 6133b
+
+--spock.tables should be empty
+SELECT * FROM spock.tables ORDER BY relid;
+-- none of these tables should exist.
+\d sales_list_east
+\d sales_list_west
+\d sales_list_north
+\d sales_list
+
+/*
+\d+ products_list
+\d+ products_list_clothing
+\d+ products_list_electronics
+*/

--- a/t/auto_ddl/6144a_table_hash_partitions_n1.out
+++ b/t/auto_ddl/6144a_table_hash_partitions_n1.out
@@ -1,0 +1,283 @@
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+-----------------------------
+-- Hash Partitioning Examples
+-----------------------------
+-- Create a hash partitioned table with primary key
+CREATE TABLE sales_hash (
+    sale_id INT,
+    sale_date DATE,
+    sale_amount DECIMAL,
+    PRIMARY KEY (sale_id, sale_date)
+) PARTITION BY HASH (sale_id);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Add partitions to the sales_hash table
+CREATE TABLE sales_hash_1 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE sales_hash_2 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE sales_hash_3 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE sales_hash_4 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert data into the sales_hash table
+INSERT INTO sales_hash (sale_id, sale_date, sale_amount) VALUES
+(1, '2023-01-01', 100.0),
+(2, '2023-01-02', 200.0),
+(3, '2023-01-03', 150.0),
+(4, '2023-01-04', 250.0);
+INSERT 0 4
+EXECUTE spocktab('sales_hash'); -- Expect both parent and child tables in default repset
+ nspname |   relname    | set_name 
+---------+--------------+----------
+ public  | sales_hash   | default
+ public  | sales_hash_1 | default
+ public  | sales_hash_2 | default
+ public  | sales_hash_3 | default
+ public  | sales_hash_4 | default
+(5 rows)
+
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+ sale_id | sale_date  | sale_amount 
+---------+------------+-------------
+       1 | 2023-01-01 |       100.0
+       2 | 2023-01-02 |       200.0
+       3 | 2023-01-03 |       150.0
+       4 | 2023-01-04 |       250.0
+(4 rows)
+
+-- Validate structure and data after adding new partition
+\d sales_hash_1
+              Table "public.sales_hash_1"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 0)
+Indexes:
+    "sales_hash_1_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_2
+              Table "public.sales_hash_2"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 1)
+Indexes:
+    "sales_hash_2_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_3
+              Table "public.sales_hash_3"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 2)
+Indexes:
+    "sales_hash_3_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_4
+              Table "public.sales_hash_4"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 3)
+Indexes:
+    "sales_hash_4_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash
+         Partitioned table "public.sales_hash"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition key: HASH (sale_id)
+Indexes:
+    "sales_hash_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+Number of partitions: 4 (Use \d+ to list them.)
+
+EXECUTE spocktab('sales_hash'); -- Expect all partitions to be listed
+ nspname |   relname    | set_name 
+---------+--------------+----------
+ public  | sales_hash   | default
+ public  | sales_hash_1 | default
+ public  | sales_hash_2 | default
+ public  | sales_hash_3 | default
+ public  | sales_hash_4 | default
+(5 rows)
+
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+ sale_id | sale_date  | sale_amount 
+---------+------------+-------------
+       1 | 2023-01-01 |       100.0
+       2 | 2023-01-02 |       200.0
+       3 | 2023-01-03 |       150.0
+       4 | 2023-01-04 |       250.0
+(4 rows)
+
+-- Create a hash partitioned table without primary key
+CREATE TABLE products_hash (
+    product_id INT,
+    product_date DATE,
+    product_name TEXT
+) PARTITION BY HASH (product_id);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Add partitions to the products_hash table
+CREATE TABLE products_hash_1 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE products_hash_2 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE products_hash_3 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE products_hash_4 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert data into the products_hash table
+INSERT INTO products_hash (product_id, product_date, product_name) VALUES
+(1, '2023-01-01', 'Laptop'),
+(2, '2023-01-02', 'Shirt'),
+(3, '2023-01-03', 'Smartphone'),
+(4, '2023-01-04', 'Tablet');
+INSERT 0 4
+-- Validate structure and data
+\d+ products_hash
+                                   Partitioned table "public.products_hash"
+    Column    |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ product_id   | integer |           |          |         | plain    |             |              | 
+ product_date | date    |           |          |         | plain    |             |              | 
+ product_name | text    |           |          |         | extended |             |              | 
+Partition key: HASH (product_id)
+Partitions: products_hash_1 FOR VALUES WITH (modulus 4, remainder 0),
+            products_hash_2 FOR VALUES WITH (modulus 4, remainder 1),
+            products_hash_3 FOR VALUES WITH (modulus 4, remainder 2),
+            products_hash_4 FOR VALUES WITH (modulus 4, remainder 3)
+
+EXECUTE spocktab('products_hash'); -- Expect both parent and child tables in default_insert_only set
+ nspname |     relname     |      set_name       
+---------+-----------------+---------------------
+ public  | products_hash   | default_insert_only
+ public  | products_hash_1 | default_insert_only
+ public  | products_hash_2 | default_insert_only
+ public  | products_hash_3 | default_insert_only
+ public  | products_hash_4 | default_insert_only
+(5 rows)
+
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows
+ product_id | product_date | product_name 
+------------+--------------+--------------
+          1 | 2023-01-01   | Laptop
+          2 | 2023-01-02   | Shirt
+          3 | 2023-01-03   | Smartphone
+          4 | 2023-01-04   | Tablet
+(4 rows)
+
+-- Alter the products_hash table to add a primary key
+ALTER TABLE products_hash ADD PRIMARY KEY (product_id, product_date);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate structure and data after adding primary key
+\d products_hash
+        Partitioned table "public.products_hash"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition key: HASH (product_id)
+Indexes:
+    "products_hash_pkey" PRIMARY KEY, btree (product_id, product_date)
+Number of partitions: 4 (Use \d+ to list them.)
+
+\d products_hash_1
+             Table "public.products_hash_1"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 0)
+Indexes:
+    "products_hash_1_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_2
+             Table "public.products_hash_2"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 1)
+Indexes:
+    "products_hash_2_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_3
+             Table "public.products_hash_3"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 2)
+Indexes:
+    "products_hash_3_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_4
+             Table "public.products_hash_4"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 3)
+Indexes:
+    "products_hash_4_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+only the parent table moves to default repset, all partitions continue to stay in default_insert_only
+*/
+EXECUTE spocktab('products_hash'); -- Expect the replication set to change to default
+ nspname |     relname     |      set_name       
+---------+-----------------+---------------------
+ public  | products_hash   | default
+ public  | products_hash_1 | default_insert_only
+ public  | products_hash_2 | default_insert_only
+ public  | products_hash_3 | default_insert_only
+ public  | products_hash_4 | default_insert_only
+(5 rows)
+
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows
+ product_id | product_date | product_name 
+------------+--------------+--------------
+          1 | 2023-01-01   | Laptop
+          2 | 2023-01-02   | Shirt
+          3 | 2023-01-03   | Smartphone
+          4 | 2023-01-04   | Tablet
+(4 rows)
+

--- a/t/auto_ddl/6144a_table_hash_partitions_n1.sql
+++ b/t/auto_ddl/6144a_table_hash_partitions_n1.sql
@@ -1,0 +1,88 @@
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+-----------------------------
+-- Hash Partitioning Examples
+-----------------------------
+
+-- Create a hash partitioned table with primary key
+CREATE TABLE sales_hash (
+    sale_id INT,
+    sale_date DATE,
+    sale_amount DECIMAL,
+    PRIMARY KEY (sale_id, sale_date)
+) PARTITION BY HASH (sale_id);
+
+-- Add partitions to the sales_hash table
+CREATE TABLE sales_hash_1 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE sales_hash_2 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+CREATE TABLE sales_hash_3 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+CREATE TABLE sales_hash_4 PARTITION OF sales_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+
+-- Insert data into the sales_hash table
+INSERT INTO sales_hash (sale_id, sale_date, sale_amount) VALUES
+(1, '2023-01-01', 100.0),
+(2, '2023-01-02', 200.0),
+(3, '2023-01-03', 150.0),
+(4, '2023-01-04', 250.0);
+
+EXECUTE spocktab('sales_hash'); -- Expect both parent and child tables in default repset
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+
+-- Validate structure and data after adding new partition
+\d sales_hash_1
+\d sales_hash_2
+\d sales_hash_3
+\d sales_hash_4
+\d sales_hash
+EXECUTE spocktab('sales_hash'); -- Expect all partitions to be listed
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+
+-- Create a hash partitioned table without primary key
+CREATE TABLE products_hash (
+    product_id INT,
+    product_date DATE,
+    product_name TEXT
+) PARTITION BY HASH (product_id);
+
+-- Add partitions to the products_hash table
+CREATE TABLE products_hash_1 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE products_hash_2 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+CREATE TABLE products_hash_3 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+CREATE TABLE products_hash_4 PARTITION OF products_hash
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+
+-- Insert data into the products_hash table
+INSERT INTO products_hash (product_id, product_date, product_name) VALUES
+(1, '2023-01-01', 'Laptop'),
+(2, '2023-01-02', 'Shirt'),
+(3, '2023-01-03', 'Smartphone'),
+(4, '2023-01-04', 'Tablet');
+
+-- Validate structure and data
+\d+ products_hash
+EXECUTE spocktab('products_hash'); -- Expect both parent and child tables in default_insert_only set
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows
+
+-- Alter the products_hash table to add a primary key
+ALTER TABLE products_hash ADD PRIMARY KEY (product_id, product_date);
+
+-- Validate structure and data after adding primary key
+\d products_hash
+\d products_hash_1
+\d products_hash_2
+\d products_hash_3
+\d products_hash_4
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+only the parent table moves to default repset, all partitions continue to stay in default_insert_only
+*/
+EXECUTE spocktab('products_hash'); -- Expect the replication set to change to default
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows

--- a/t/auto_ddl/6144b_table_hash_partitions_validate_n2.out
+++ b/t/auto_ddl/6144b_table_hash_partitions_validate_n2.out
@@ -1,0 +1,177 @@
+--This file will run on n2 and validate all the replicated tables data, structure and replication sets they're in
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+-- Validate structure and data after adding new partition
+\d sales_hash_1
+              Table "public.sales_hash_1"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 0)
+Indexes:
+    "sales_hash_1_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_2
+              Table "public.sales_hash_2"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 1)
+Indexes:
+    "sales_hash_2_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_3
+              Table "public.sales_hash_3"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 2)
+Indexes:
+    "sales_hash_3_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash_4
+              Table "public.sales_hash_4"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition of: sales_hash FOR VALUES WITH (modulus 4, remainder 3)
+Indexes:
+    "sales_hash_4_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+
+\d sales_hash
+         Partitioned table "public.sales_hash"
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ sale_id     | integer |           | not null | 
+ sale_date   | date    |           | not null | 
+ sale_amount | numeric |           |          | 
+Partition key: HASH (sale_id)
+Indexes:
+    "sales_hash_pkey" PRIMARY KEY, btree (sale_id, sale_date)
+Number of partitions: 4 (Use \d+ to list them.)
+
+EXECUTE spocktab('sales_hash'); -- Expect all partitions to be listed
+ nspname |   relname    | set_name 
+---------+--------------+----------
+ public  | sales_hash   | default
+ public  | sales_hash_1 | default
+ public  | sales_hash_2 | default
+ public  | sales_hash_3 | default
+ public  | sales_hash_4 | default
+(5 rows)
+
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+ sale_id | sale_date  | sale_amount 
+---------+------------+-------------
+       1 | 2023-01-01 |       100.0
+       2 | 2023-01-02 |       200.0
+       3 | 2023-01-03 |       150.0
+       4 | 2023-01-04 |       250.0
+(4 rows)
+
+--exercise ddl on n2
+DROP TABLE sales_hash CASCADE;
+NOTICE:  drop cascades to table sales_hash_4 membership in replication set default
+NOTICE:  drop cascades to table sales_hash_3 membership in replication set default
+NOTICE:  drop cascades to table sales_hash_2 membership in replication set default
+NOTICE:  drop cascades to table sales_hash_1 membership in replication set default
+NOTICE:  drop cascades to table sales_hash membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+\d products_hash
+        Partitioned table "public.products_hash"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition key: HASH (product_id)
+Indexes:
+    "products_hash_pkey" PRIMARY KEY, btree (product_id, product_date)
+Number of partitions: 4 (Use \d+ to list them.)
+
+\d products_hash_1
+             Table "public.products_hash_1"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 0)
+Indexes:
+    "products_hash_1_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_2
+             Table "public.products_hash_2"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 1)
+Indexes:
+    "products_hash_2_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_3
+             Table "public.products_hash_3"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 2)
+Indexes:
+    "products_hash_3_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+\d products_hash_4
+             Table "public.products_hash_4"
+    Column    |  Type   | Collation | Nullable | Default 
+--------------+---------+-----------+----------+---------
+ product_id   | integer |           | not null | 
+ product_date | date    |           | not null | 
+ product_name | text    |           |          | 
+Partition of: products_hash FOR VALUES WITH (modulus 4, remainder 3)
+Indexes:
+    "products_hash_4_pkey" PRIMARY KEY, btree (product_id, product_date)
+
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+only the parent table moves to default repset, all partitions continue to stay in default_insert_only
+*/
+EXECUTE spocktab('products_hash'); -- Expect the replication set to change to default
+ nspname |     relname     |      set_name       
+---------+-----------------+---------------------
+ public  | products_hash   | default
+ public  | products_hash_1 | default_insert_only
+ public  | products_hash_2 | default_insert_only
+ public  | products_hash_3 | default_insert_only
+ public  | products_hash_4 | default_insert_only
+(5 rows)
+
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows
+ product_id | product_date | product_name 
+------------+--------------+--------------
+          1 | 2023-01-01   | Laptop
+          2 | 2023-01-02   | Shirt
+          3 | 2023-01-03   | Smartphone
+          4 | 2023-01-04   | Tablet
+(4 rows)
+
+--exercise ddl on n2
+DROP TABLE products_hash CASCADE;
+NOTICE:  drop cascades to table products_hash_4 membership in replication set default_insert_only
+NOTICE:  drop cascades to table products_hash_3 membership in replication set default_insert_only
+NOTICE:  drop cascades to table products_hash_2 membership in replication set default_insert_only
+NOTICE:  drop cascades to table products_hash_1 membership in replication set default_insert_only
+NOTICE:  drop cascades to table products_hash membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE

--- a/t/auto_ddl/6144b_table_hash_partitions_validate_n2.sql
+++ b/t/auto_ddl/6144b_table_hash_partitions_validate_n2.sql
@@ -1,0 +1,28 @@
+--This file will run on n2 and validate all the replicated tables data, structure and replication sets they're in
+-- Prepared statement for spock.tables to list parent and child tables as parent table name will be contained in partition name
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+-- Validate structure and data after adding new partition
+\d sales_hash_1
+\d sales_hash_2
+\d sales_hash_3
+\d sales_hash_4
+\d sales_hash
+EXECUTE spocktab('sales_hash'); -- Expect all partitions to be listed
+SELECT * FROM sales_hash ORDER BY sale_id; -- Expect 4 rows
+--exercise ddl on n2
+DROP TABLE sales_hash CASCADE;
+
+\d products_hash
+\d products_hash_1
+\d products_hash_2
+\d products_hash_3
+\d products_hash_4
+/*TO FIX:
+commenting this test case due to https://github.com/orgs/pgEdge/projects/6/views/7?filterQuery=category%3AAutoDDL+&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C77649763%5D&pane=issue&itemId=69962278
+only the parent table moves to default repset, all partitions continue to stay in default_insert_only
+*/
+EXECUTE spocktab('products_hash'); -- Expect the replication set to change to default
+SELECT * FROM products_hash ORDER BY product_id; -- Expect 4 rows
+--exercise ddl on n2
+DROP TABLE products_hash CASCADE;

--- a/t/auto_ddl/6144c_table_hash_parition_validate_n1.out
+++ b/t/auto_ddl/6144c_table_hash_parition_validate_n1.out
@@ -1,0 +1,31 @@
+-- This file runs on n1 again to see all the table and their partitions have been dropped on n1 (as a result of drop statements)
+-- being auto replicated via 6144b
+--spock.tables should be empty
+SELECT * FROM spock.tables ORDER BY relid;
+ relid | nspname | relname | set_name 
+-------+---------+---------+----------
+(0 rows)
+
+-- none of these tables should exist.
+\d sales_hash_1
+Did not find any relation named "sales_hash_1".
+\d sales_hash_2
+Did not find any relation named "sales_hash_2".
+\d sales_hash_3
+Did not find any relation named "sales_hash_3".
+\d sales_hash_4
+Did not find any relation named "sales_hash_4".
+\d sales_hash
+Did not find any relation named "sales_hash".
+/*
+*/
+\d products_hash
+Did not find any relation named "products_hash".
+\d products_hash_1
+Did not find any relation named "products_hash_1".
+\d products_hash_2
+Did not find any relation named "products_hash_2".
+\d products_hash_3
+Did not find any relation named "products_hash_3".
+\d products_hash_4
+Did not find any relation named "products_hash_4".

--- a/t/auto_ddl/6144c_table_hash_parition_validate_n1.sql
+++ b/t/auto_ddl/6144c_table_hash_parition_validate_n1.sql
@@ -1,0 +1,19 @@
+-- This file runs on n1 again to see all the table and their partitions have been dropped on n1 (as a result of drop statements)
+-- being auto replicated via 6144b
+
+--spock.tables should be empty
+SELECT * FROM spock.tables ORDER BY relid;
+-- none of these tables should exist.
+\d sales_hash_1
+\d sales_hash_2
+\d sales_hash_3
+\d sales_hash_4
+\d sales_hash
+
+/*
+*/
+\d products_hash
+\d products_hash_1
+\d products_hash_2
+\d products_hash_3
+\d products_hash_4


### PR DESCRIPTION
Add autoDDL tests to cover :

- HASH table partitioning (6144a, 6144b, 6144c)
- LIST table partitioning (6133a, 6133b, 6133c)
