### PR TITLE
AutoDDL tests 6177a, 6177b, and 6177c to validate the spock.allow_ddl_from_functions GUC

### DIFF
--- a/schedule_files/auto_ddl_schedule
+++ b/schedule_files/auto_ddl_schedule
@@ -45,6 +45,9 @@ t/auto_ddl/6155c_index_validate_drop_n1.sql
 t/auto_ddl/6166a_views_materialized_views_n1.sql
 t/auto_ddl/6166b_view_mat_views_validate_n2.sql
 t/auto_ddl/6166c_views_mat_view_validate_n1.sql
+t/auto_ddl/6177a_allow_ddl_from_func_proc_create_alter_n1.sql
+t/auto_ddl/6177b_allow_ddl_from_func_proc_validate_drop_n2.sql
+t/auto_ddl/6177c_allow_ddl_from_func_proc_validate_n1.sql
 t/auto_ddl/6666a_all_objects_create_n1.sql
 t/auto_ddl/6666b_all_objects_validate_and_drop_n2.sql
 t/auto_ddl/6666c_all_objects_validate_n1.sql

--- a/t/auto_ddl/6177a_allow_ddl_from_func_proc_create_alter_n1.out
+++ b/t/auto_ddl/6177a_allow_ddl_from_func_proc_create_alter_n1.out
@@ -1,0 +1,394 @@
+-- Prepared statement for spock.tables to list tables and associated indexes
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SHOW spock.allow_ddl_from_functions;
+ spock.allow_ddl_from_functions 
+--------------------------------
+ on
+(1 row)
+
+-- Create simple tables
+CREATE TABLE tab1_proc_on (id INT PRIMARY KEY, col1 TEXT, col2 INT);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE tab2_func_on (id INT PRIMARY KEY, col1 TEXT, col2 INT, col3 TEXT, col4 INT, col5 TEXT, col6 INT, col7 TEXT, col8 INT);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Create tables within anonymous blocks
+DO $$
+BEGIN
+  EXECUTE 'CREATE TABLE tab3_anon_on (id INT, col1 TEXT, col2 INT)';
+  EXECUTE 'CREATE TABLE tab6_anon_off (id INT PRIMARY KEY, col1 TEXT, col2 INT)';
+END
+$$;
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+DO
+CREATE TABLE tab4_proc_off (id INT PRIMARY KEY, col1 TEXT, col2 INT);
+INFO:  DDL statement replicated.
+CREATE TABLE
+CREATE TABLE tab5_func_off (id INT PRIMARY KEY, col1 TEXT, col2 INT, col3 TEXT, col4 INT, col5 TEXT, col6 INT, col7 TEXT, col8 INT);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert sample data
+INSERT INTO tab1_proc_on (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT 0 1
+INSERT INTO tab2_func_on (id, col1, col2, col3, col4, col5, col6, col7, col8) VALUES (1, 'data2', 200, 'data3', 300, 'data4', 400, 'data5', 500);
+INSERT 0 1
+INSERT INTO tab3_anon_on (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT 0 1
+INSERT INTO tab4_proc_off (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT 0 1
+INSERT INTO tab5_func_off (id, col1, col2, col3, col4, col5, col6, col7, col8) VALUES (1, 'data2', 200, 'data3', 300, 'data4', 400, 'data5', 500);
+INSERT 0 1
+INSERT INTO tab6_anon_off (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT 0 1
+-- Create procedure that internally executes a DDL to add columns dynamically to the passed table
+CREATE OR REPLACE PROCEDURE add_column_to_table_proc(
+    table_name VARCHAR(50),
+    varname VARCHAR(50),
+    vartype VARCHAR(50),
+    IN OUT success BOOLEAN
+) AS $$
+BEGIN
+    EXECUTE 'ALTER TABLE ' || table_name || ' ADD COLUMN ' || varname || ' ' || vartype;
+    success := true;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'Error: %', SQLERRM;
+        success := false;
+END;
+$$ LANGUAGE plpgsql;
+INFO:  DDL statement replicated.
+CREATE PROCEDURE
+-- Create function that internally exdcutes a DDL to drop columns dynamically from the passed table
+CREATE OR REPLACE FUNCTION remove_column_from_table(
+    table_name VARCHAR(50),
+    column_name VARCHAR(50)
+) RETURNS BOOLEAN AS $$
+BEGIN
+    EXECUTE 'ALTER TABLE ' || table_name || ' DROP COLUMN ' || column_name;
+    RETURN TRUE;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+INFO:  DDL statement replicated.
+CREATE FUNCTION
+-- Create the tab_emp table
+CREATE TABLE tab_emp (
+    id INT PRIMARY KEY,
+    name VARCHAR(255),
+    salary NUMERIC
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Create a trigger function
+CREATE OR REPLACE FUNCTION employee_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    EXECUTE 'CREATE SCHEMA ' || NEW.name;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+INFO:  DDL statement replicated.
+CREATE FUNCTION
+-- Create the trigger to execute the function after an insert
+CREATE TRIGGER employee_insert_trigger
+AFTER INSERT
+ON tab_emp
+FOR EACH ROW
+EXECUTE FUNCTION employee_insert_trigger();
+INFO:  DDL statement replicated.
+CREATE TRIGGER
+EXECUTE spocktab('tab'); 
+ nspname |    relname    |      set_name       
+---------+---------------+---------------------
+ public  | tab1_proc_on  | default
+ public  | tab2_func_on  | default
+ public  | tab3_anon_on  | default_insert_only
+ public  | tab6_anon_off | default
+ public  | tab4_proc_off | default
+ public  | tab5_func_off | default
+ public  | tab_emp       | default
+(7 rows)
+
+-- Add a primary key to the table tab3 within an anonymous block
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE tab3_anon_on ADD PRIMARY KEY (id)';
+END
+$$;
+INFO:  DDL statement replicated.
+DO
+-- Execute the procedure to add columns
+CALL add_column_to_table_proc('tab1_proc_on', 'new_col1', 'CHAR', true);
+INFO:  DDL statement replicated.
+ success 
+---------
+ t
+(1 row)
+
+CALL add_column_to_table_proc('tab1_proc_on', 'new_col2', 'BOOL', true);
+INFO:  DDL statement replicated.
+ success 
+---------
+ t
+(1 row)
+
+-- Execute the function to drop columns
+SELECT remove_column_from_table('tab2_func_on', 'col3');
+INFO:  DDL statement replicated.
+ remove_column_from_table 
+--------------------------
+ t
+(1 row)
+
+SELECT remove_column_from_table('tab2_func_on', 'col5');
+INFO:  DDL statement replicated.
+ remove_column_from_table 
+--------------------------
+ t
+(1 row)
+
+-- Trigger DDL execution via trigger, that should create a schema named john and auto replicate it
+INSERT INTO tab_emp (id, name, salary) VALUES (1, 'John', 50000);
+INFO:  DDL statement replicated.
+INSERT 0 1
+EXECUTE spocktab('tab'); 
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | tab1_proc_on  | default
+ public  | tab2_func_on  | default
+ public  | tab3_anon_on  | default
+ public  | tab6_anon_off | default
+ public  | tab4_proc_off | default
+ public  | tab5_func_off | default
+ public  | tab_emp       | default
+(7 rows)
+
+------
+-- Turning allow_ddl_from_functions GUC off
+------
+-- Turn off the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = off;
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SHOW spock.allow_ddl_from_functions;
+ spock.allow_ddl_from_functions 
+--------------------------------
+ off
+(1 row)
+
+-- Run anonymous block to create tab7
+DO $$
+BEGIN
+  EXECUTE 'CREATE TABLE tab7_anon_off (id INT, col1 TEXT, col2 INT)';
+  EXECUTE 'ALTER TABLE tab6_anon_off DROP COLUMN id';
+END
+$$;
+DO
+-- Execute the procedure to add columns
+CALL add_column_to_table_proc('tab4_proc_off', 'new_col1', 'CHAR', true);
+ success 
+---------
+ t
+(1 row)
+
+CALL add_column_to_table_proc('tab4_proc_off', 'new_col2', 'BOOL', true);
+ success 
+---------
+ t
+(1 row)
+
+-- Execute the function to drop columns
+SELECT remove_column_from_table('tab5_func_off', 'col3');
+ remove_column_from_table 
+--------------------------
+ t
+(1 row)
+
+SELECT remove_column_from_table('tab5_func_off', 'col5');
+ remove_column_from_table 
+--------------------------
+ t
+(1 row)
+
+-- Trigger DDL execution via trigger
+INSERT INTO tab_emp (id, name, salary) VALUES (2, 'Alice', 60000);
+INSERT 0 1
+-- Validate table structures and schemas
+\df add_column*
+                                                                                List of functions
+ Schema |           Name           | Result data type |                                                Argument data types                                                 | Type 
+--------+--------------------------+------------------+--------------------------------------------------------------------------------------------------------------------+------
+ public | add_column_to_table_proc |                  | IN table_name character varying, IN varname character varying, IN vartype character varying, INOUT success boolean | proc
+(1 row)
+
+\df remove_column*
+                                                     List of functions
+ Schema |           Name           | Result data type |                     Argument data types                     | Type 
+--------+--------------------------+------------------+-------------------------------------------------------------+------
+ public | remove_column_from_table | boolean          | table_name character varying, column_name character varying | func
+(1 row)
+
+\df employee_insert_trigger
+                                List of functions
+ Schema |          Name           | Result data type | Argument data types | Type 
+--------+-------------------------+------------------+---------------------+------
+ public | employee_insert_trigger | trigger          |                     | func
+(1 row)
+
+\d+ tab1_proc_on
+                                          Table "public.tab1_proc_on"
+  Column  |     Type     | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+--------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | integer      |           | not null |         | plain    |             |              | 
+ col1     | text         |           |          |         | extended |             |              | 
+ col2     | integer      |           |          |         | plain    |             |              | 
+ new_col1 | character(1) |           |          |         | extended |             |              | 
+ new_col2 | boolean      |           |          |         | plain    |             |              | 
+Indexes:
+    "tab1_proc_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab2_func_on
+                                       Table "public.tab2_func_on"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+ col4   | integer |           |          |         | plain    |             |              | 
+ col6   | integer |           |          |         | plain    |             |              | 
+ col7   | text    |           |          |         | extended |             |              | 
+ col8   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab2_func_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab3_anon_on
+                                       Table "public.tab3_anon_on"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab3_anon_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab4_proc_off
+                                          Table "public.tab4_proc_off"
+  Column  |     Type     | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+--------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | integer      |           | not null |         | plain    |             |              | 
+ col1     | text         |           |          |         | extended |             |              | 
+ col2     | integer      |           |          |         | plain    |             |              | 
+ new_col1 | character(1) |           |          |         | extended |             |              | 
+ new_col2 | boolean      |           |          |         | plain    |             |              | 
+Indexes:
+    "tab4_proc_off_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab5_func_off
+                                      Table "public.tab5_func_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+ col4   | integer |           |          |         | plain    |             |              | 
+ col6   | integer |           |          |         | plain    |             |              | 
+ col7   | text    |           |          |         | extended |             |              | 
+ col8   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab5_func_off_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab6_anon_off
+                                      Table "public.tab6_anon_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Access method: heap
+
+\d+ tab7_anon_off
+                                      Table "public.tab7_anon_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           |          |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Access method: heap
+
+\d+ tab_emp
+                                                 Table "public.tab_emp"
+ Column |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer                |           | not null |         | plain    |             |              | 
+ name   | character varying(255) |           |          |         | extended |             |              | 
+ salary | numeric                |           |          |         | main     |             |              | 
+Indexes:
+    "tab_emp_pkey" PRIMARY KEY, btree (id)
+Triggers:
+    employee_insert_trigger AFTER INSERT ON tab_emp FOR EACH ROW EXECUTE FUNCTION employee_insert_trigger()
+Access method: heap
+
+\dn john
+List of schemas
+ Name | Owner 
+------+-------
+ john | rocky
+(1 row)
+
+\dn alice
+List of schemas
+ Name  | Owner 
+-------+-------
+ alice | rocky
+(1 row)
+
+EXECUTE spocktab('tab'); 
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | tab1_proc_on  | default
+ public  | tab2_func_on  | default
+ public  | tab3_anon_on  | default
+ public  | tab6_anon_off | default
+ public  | tab4_proc_off | default
+ public  | tab5_func_off | default
+ public  | tab_emp       | default
+ public  | tab7_anon_off | 
+(8 rows)
+

--- a/t/auto_ddl/6177a_allow_ddl_from_func_proc_create_alter_n1.sql
+++ b/t/auto_ddl/6177a_allow_ddl_from_func_proc_create_alter_n1.sql
@@ -1,0 +1,153 @@
+-- Prepared statement for spock.tables to list tables and associated indexes
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.5);
+SHOW spock.allow_ddl_from_functions;
+
+-- Create simple tables
+CREATE TABLE tab1_proc_on (id INT PRIMARY KEY, col1 TEXT, col2 INT);
+CREATE TABLE tab2_func_on (id INT PRIMARY KEY, col1 TEXT, col2 INT, col3 TEXT, col4 INT, col5 TEXT, col6 INT, col7 TEXT, col8 INT);
+-- Create tables within anonymous blocks
+DO $$
+BEGIN
+  EXECUTE 'CREATE TABLE tab3_anon_on (id INT, col1 TEXT, col2 INT)';
+  EXECUTE 'CREATE TABLE tab6_anon_off (id INT PRIMARY KEY, col1 TEXT, col2 INT)';
+END
+$$;
+CREATE TABLE tab4_proc_off (id INT PRIMARY KEY, col1 TEXT, col2 INT);
+CREATE TABLE tab5_func_off (id INT PRIMARY KEY, col1 TEXT, col2 INT, col3 TEXT, col4 INT, col5 TEXT, col6 INT, col7 TEXT, col8 INT);
+
+-- Insert sample data
+INSERT INTO tab1_proc_on (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT INTO tab2_func_on (id, col1, col2, col3, col4, col5, col6, col7, col8) VALUES (1, 'data2', 200, 'data3', 300, 'data4', 400, 'data5', 500);
+INSERT INTO tab3_anon_on (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT INTO tab4_proc_off (id, col1, col2) VALUES (1, 'data1', 100);
+INSERT INTO tab5_func_off (id, col1, col2, col3, col4, col5, col6, col7, col8) VALUES (1, 'data2', 200, 'data3', 300, 'data4', 400, 'data5', 500);
+INSERT INTO tab6_anon_off (id, col1, col2) VALUES (1, 'data1', 100);
+
+-- Create procedure that internally executes a DDL to add columns dynamically to the passed table
+CREATE OR REPLACE PROCEDURE add_column_to_table_proc(
+    table_name VARCHAR(50),
+    varname VARCHAR(50),
+    vartype VARCHAR(50),
+    IN OUT success BOOLEAN
+) AS $$
+BEGIN
+    EXECUTE 'ALTER TABLE ' || table_name || ' ADD COLUMN ' || varname || ' ' || vartype;
+    success := true;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'Error: %', SQLERRM;
+        success := false;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create function that internally exdcutes a DDL to drop columns dynamically from the passed table
+CREATE OR REPLACE FUNCTION remove_column_from_table(
+    table_name VARCHAR(50),
+    column_name VARCHAR(50)
+) RETURNS BOOLEAN AS $$
+BEGIN
+    EXECUTE 'ALTER TABLE ' || table_name || ' DROP COLUMN ' || column_name;
+    RETURN TRUE;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the tab_emp table
+CREATE TABLE tab_emp (
+    id INT PRIMARY KEY,
+    name VARCHAR(255),
+    salary NUMERIC
+);
+
+-- Create a trigger function
+CREATE OR REPLACE FUNCTION employee_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    EXECUTE 'CREATE SCHEMA ' || NEW.name;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger to execute the function after an insert
+CREATE TRIGGER employee_insert_trigger
+AFTER INSERT
+ON tab_emp
+FOR EACH ROW
+EXECUTE FUNCTION employee_insert_trigger();
+
+EXECUTE spocktab('tab'); 
+
+-- Add a primary key to the table tab3 within an anonymous block
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE tab3_anon_on ADD PRIMARY KEY (id)';
+END
+$$;
+
+
+-- Execute the procedure to add columns
+CALL add_column_to_table_proc('tab1_proc_on', 'new_col1', 'CHAR', true);
+CALL add_column_to_table_proc('tab1_proc_on', 'new_col2', 'BOOL', true);
+
+-- Execute the function to drop columns
+SELECT remove_column_from_table('tab2_func_on', 'col3');
+SELECT remove_column_from_table('tab2_func_on', 'col5');
+
+-- Trigger DDL execution via trigger, that should create a schema named john and auto replicate it
+INSERT INTO tab_emp (id, name, salary) VALUES (1, 'John', 50000);
+
+EXECUTE spocktab('tab'); 
+
+------
+-- Turning allow_ddl_from_functions GUC off
+------
+
+-- Turn off the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = off;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.5);
+SHOW spock.allow_ddl_from_functions;
+
+-- Run anonymous block to create tab7
+DO $$
+BEGIN
+  EXECUTE 'CREATE TABLE tab7_anon_off (id INT, col1 TEXT, col2 INT)';
+  EXECUTE 'ALTER TABLE tab6_anon_off DROP COLUMN id';
+END
+$$;
+
+-- Execute the procedure to add columns
+CALL add_column_to_table_proc('tab4_proc_off', 'new_col1', 'CHAR', true);
+CALL add_column_to_table_proc('tab4_proc_off', 'new_col2', 'BOOL', true);
+
+-- Execute the function to drop columns
+SELECT remove_column_from_table('tab5_func_off', 'col3');
+SELECT remove_column_from_table('tab5_func_off', 'col5');
+
+-- Trigger DDL execution via trigger
+INSERT INTO tab_emp (id, name, salary) VALUES (2, 'Alice', 60000);
+
+-- Validate table structures and schemas
+\df add_column*
+\df remove_column*
+\df employee_insert_trigger
+\d+ tab1_proc_on
+\d+ tab2_func_on
+\d+ tab3_anon_on
+\d+ tab4_proc_off
+\d+ tab5_func_off
+\d+ tab6_anon_off
+\d+ tab7_anon_off
+\d+ tab_emp
+\dn john
+\dn alice
+
+EXECUTE spocktab('tab'); 

--- a/t/auto_ddl/6177b_allow_ddl_from_func_proc_validate_drop_n2.out
+++ b/t/auto_ddl/6177b_allow_ddl_from_func_proc_validate_drop_n2.out
@@ -1,0 +1,211 @@
+-- Prepared statement for spock.tables to list tables and associated indexes
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+PREPARE
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SHOW spock.allow_ddl_from_functions;
+ spock.allow_ddl_from_functions 
+--------------------------------
+ on
+(1 row)
+
+-- Validate replicated functions, procedures, tables
+\df add_column*
+                                                                                List of functions
+ Schema |           Name           | Result data type |                                                Argument data types                                                 | Type 
+--------+--------------------------+------------------+--------------------------------------------------------------------------------------------------------------------+------
+ public | add_column_to_table_proc |                  | IN table_name character varying, IN varname character varying, IN vartype character varying, INOUT success boolean | proc
+(1 row)
+
+\df remove_column*
+                                                     List of functions
+ Schema |           Name           | Result data type |                     Argument data types                     | Type 
+--------+--------------------------+------------------+-------------------------------------------------------------+------
+ public | remove_column_from_table | boolean          | table_name character varying, column_name character varying | func
+(1 row)
+
+\df employee_insert_trigger
+                                List of functions
+ Schema |          Name           | Result data type | Argument data types | Type 
+--------+-------------------------+------------------+---------------------+------
+ public | employee_insert_trigger | trigger          |                     | func
+(1 row)
+
+\d+ tab1_proc_on
+                                          Table "public.tab1_proc_on"
+  Column  |     Type     | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+--------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | integer      |           | not null |         | plain    |             |              | 
+ col1     | text         |           |          |         | extended |             |              | 
+ col2     | integer      |           |          |         | plain    |             |              | 
+ new_col1 | character(1) |           |          |         | extended |             |              | 
+ new_col2 | boolean      |           |          |         | plain    |             |              | 
+Indexes:
+    "tab1_proc_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab2_func_on
+                                       Table "public.tab2_func_on"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+ col4   | integer |           |          |         | plain    |             |              | 
+ col6   | integer |           |          |         | plain    |             |              | 
+ col7   | text    |           |          |         | extended |             |              | 
+ col8   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab2_func_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab3_anon_on
+                                       Table "public.tab3_anon_on"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab3_anon_on_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab4_proc_off
+                                      Table "public.tab4_proc_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab4_proc_off_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab5_func_off
+                                      Table "public.tab5_func_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+ col3   | text    |           |          |         | extended |             |              | 
+ col4   | integer |           |          |         | plain    |             |              | 
+ col5   | text    |           |          |         | extended |             |              | 
+ col6   | integer |           |          |         | plain    |             |              | 
+ col7   | text    |           |          |         | extended |             |              | 
+ col8   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab5_func_off_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab6_anon_off
+                                      Table "public.tab6_anon_off"
+ Column |  Type   | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+---------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer |           | not null |         | plain    |             |              | 
+ col1   | text    |           |          |         | extended |             |              | 
+ col2   | integer |           |          |         | plain    |             |              | 
+Indexes:
+    "tab6_anon_off_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+\d+ tab7_anon_off
+Did not find any relation named "tab7_anon_off".
+\d+ tab_emp
+                                                 Table "public.tab_emp"
+ Column |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id     | integer                |           | not null |         | plain    |             |              | 
+ name   | character varying(255) |           |          |         | extended |             |              | 
+ salary | numeric                |           |          |         | main     |             |              | 
+Indexes:
+    "tab_emp_pkey" PRIMARY KEY, btree (id)
+Triggers:
+    employee_insert_trigger AFTER INSERT ON tab_emp FOR EACH ROW EXECUTE FUNCTION employee_insert_trigger()
+Access method: heap
+
+\dn john
+List of schemas
+ Name | Owner 
+------+-------
+ john | rocky
+(1 row)
+
+\dn alice
+List of schemas
+ Name | Owner 
+------+-------
+(0 rows)
+
+EXECUTE spocktab('tab'); 
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | tab1_proc_on  | default
+ public  | tab2_func_on  | default
+ public  | tab3_anon_on  | default
+ public  | tab6_anon_off | default
+ public  | tab4_proc_off | default
+ public  | tab5_func_off | default
+ public  | tab_emp       | default
+(7 rows)
+
+-- Drop tables 
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab1_proc_on';
+  EXECUTE 'DROP TABLE tab2_func_on';
+  EXECUTE 'DROP TABLE tab3_anon_on';
+  EXECUTE 'DROP TABLE tab4_proc_off';
+  EXECUTE 'DROP TABLE tab5_func_off';
+  EXECUTE 'DROP TABLE tab6_anon_off';
+  EXECUTE 'DROP TABLE tab_emp CASCADE';
+  EXECUTE 'DROP PROCEDURE add_column_to_table_proc';
+  EXECUTE 'DROP FUNCTION remove_column_from_table';
+  EXECUTE 'DROP FUNCTION employee_insert_trigger';
+  EXECUTE 'DROP SCHEMA john';
+END
+$$;
+NOTICE:  drop cascades to table tab1_proc_on membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab2_func_on membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab3_anon_on membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab4_proc_off membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab5_func_off membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab6_anon_off membership in replication set default
+INFO:  DDL statement replicated.
+NOTICE:  drop cascades to table tab_emp membership in replication set default
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+DO
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab7_anon_off'; --should not exist
+END
+$$;
+ERROR:  table "tab7_anon_off" does not exist
+CONTEXT:  SQL statement "DROP TABLE tab7_anon_off"
+PL/pgSQL function inline_code_block line 3 at EXECUTE
+--should error out
+DROP SCHEMA alice;
+ERROR:  schema "alice" does not exist

--- a/t/auto_ddl/6177b_allow_ddl_from_func_proc_validate_drop_n2.sql
+++ b/t/auto_ddl/6177b_allow_ddl_from_func_proc_validate_drop_n2.sql
@@ -1,0 +1,48 @@
+-- Prepared statement for spock.tables to list tables and associated indexes
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname LIKE '%' || $1 || '%' ORDER BY relid;
+
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.5);
+SHOW spock.allow_ddl_from_functions;
+
+-- Validate replicated functions, procedures, tables
+\df add_column*
+\df remove_column*
+\df employee_insert_trigger
+\d+ tab1_proc_on
+\d+ tab2_func_on
+\d+ tab3_anon_on
+\d+ tab4_proc_off
+\d+ tab5_func_off
+\d+ tab6_anon_off
+\d+ tab7_anon_off
+\d+ tab_emp
+\dn john
+\dn alice
+EXECUTE spocktab('tab'); 
+-- Drop tables 
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab1_proc_on';
+  EXECUTE 'DROP TABLE tab2_func_on';
+  EXECUTE 'DROP TABLE tab3_anon_on';
+  EXECUTE 'DROP TABLE tab4_proc_off';
+  EXECUTE 'DROP TABLE tab5_func_off';
+  EXECUTE 'DROP TABLE tab6_anon_off';
+  EXECUTE 'DROP TABLE tab_emp CASCADE';
+  EXECUTE 'DROP PROCEDURE add_column_to_table_proc';
+  EXECUTE 'DROP FUNCTION remove_column_from_table';
+  EXECUTE 'DROP FUNCTION employee_insert_trigger';
+  EXECUTE 'DROP SCHEMA john';
+END
+$$;
+
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab7_anon_off'; --should not exist
+END
+$$;
+--should error out
+DROP SCHEMA alice;

--- a/t/auto_ddl/6177c_allow_ddl_from_func_proc_validate_n1.out
+++ b/t/auto_ddl/6177c_allow_ddl_from_func_proc_validate_n1.out
@@ -1,0 +1,95 @@
+-- Validate replicated functions, procedures, tables
+-- No objects sould exist except tab7
+\df add_column*
+                       List of functions
+ Schema | Name | Result data type | Argument data types | Type 
+--------+------+------------------+---------------------+------
+(0 rows)
+
+\df remove_column*
+                       List of functions
+ Schema | Name | Result data type | Argument data types | Type 
+--------+------+------------------+---------------------+------
+(0 rows)
+
+\df employee_insert_trigger
+                       List of functions
+ Schema | Name | Result data type | Argument data types | Type 
+--------+------+------------------+---------------------+------
+(0 rows)
+
+\d tab1_proc_on
+Did not find any relation named "tab1_proc_on".
+\d tab2_func_on
+Did not find any relation named "tab2_func_on".
+\d tab3_anon_on
+Did not find any relation named "tab3_anon_on".
+\d tab4_proc_off
+Did not find any relation named "tab4_proc_off".
+\d tab5_func_off
+Did not find any relation named "tab5_func_off".
+\d tab6_anon_off
+Did not find any relation named "tab6_anon_off".
+\d tab7_anon_off
+           Table "public.tab7_anon_off"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           |          | 
+ col1   | text    |           |          | 
+ col2   | integer |           |          | 
+
+\d tab_emp
+Did not find any relation named "tab_emp".
+\dn john
+List of schemas
+ Name | Owner 
+------+-------
+(0 rows)
+
+\dn alice
+List of schemas
+ Name  | Owner 
+-------+-------
+ alice | rocky
+(1 row)
+
+-- Turn off the allow_ddl_from_functions GUC so that these drops are not auto replicated
+ALTER SYSTEM SET spock.allow_ddl_from_functions = off;
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SHOW spock.allow_ddl_from_functions;
+ spock.allow_ddl_from_functions 
+--------------------------------
+ off
+(1 row)
+
+-- Drop tables
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab7_anon_off';
+  EXECUTE 'DROP SCHEMA alice';
+END
+$$;
+DO
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/t/auto_ddl/6177c_allow_ddl_from_func_proc_validate_n1.sql
+++ b/t/auto_ddl/6177c_allow_ddl_from_func_proc_validate_n1.sql
@@ -1,0 +1,33 @@
+-- Validate replicated functions, procedures, tables
+-- No objects sould exist except tab7
+\df add_column*
+\df remove_column*
+\df employee_insert_trigger
+\d tab1_proc_on
+\d tab2_func_on
+\d tab3_anon_on
+\d tab4_proc_off
+\d tab5_func_off
+\d tab6_anon_off
+\d tab7_anon_off
+\d tab_emp
+\dn john
+\dn alice
+
+-- Turn off the allow_ddl_from_functions GUC so that these drops are not auto replicated
+ALTER SYSTEM SET spock.allow_ddl_from_functions = off;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.5);
+SHOW spock.allow_ddl_from_functions;
+
+-- Drop tables
+DO $$
+BEGIN
+  EXECUTE 'DROP TABLE tab7_anon_off';
+  EXECUTE 'DROP SCHEMA alice';
+END
+$$;
+
+-- Turn on the allow_ddl_from_functions GUC
+ALTER SYSTEM SET spock.allow_ddl_from_functions = on;
+SELECT pg_reload_conf();


### PR DESCRIPTION
Add AutoDDL tests 6177a, 6177b, and 6177c to validate the spock.allow_ddl_from_functions GUC ensuring that DDL executed within anonymous blocks, functions, procedures, and trigger functions is only replicated when the GUC is on. When off, the DDL executed within these blocks should be executed locally only without replicating. 