### PR TITLE
Updated spock_node_create_unhappy_path tests 

### DIFF
--- a/t/spock_node_create_no_dbname.py
+++ b/t/spock_node_create_no_dbname.py
@@ -20,17 +20,6 @@ repset=os.getenv("EDGE_REPSET","demo-repset")
 spockpath=os.getenv("EDGE_SPOCK_PATH")
 dbname=os.getenv("EDGE_DB","lcdb")
 #
-# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
-# 
-check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
-print(f"Check value is: {check_value}")
-
-if "n1" in str(check_value):
-    drop_node = f"spock node-drop n1 {dbname}"
-    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
-    print(f"Print drop.stdout here: - {drop.stdout}")
-print("*"*100)
-
 # Invoke spock node-create, but don't specify a database name:
 
 command = f"spock node-create n1 'host={host} user={repuser} dbname={dbname}'"

--- a/t/spock_node_create_no_dns.py
+++ b/t/spock_node_create_no_dns.py
@@ -20,17 +20,6 @@ repset=os.getenv("EDGE_REPSET","demo-repset")
 spockpath=os.getenv("EDGE_SPOCK_PATH")
 dbname=os.getenv("EDGE_DB","lcdb")
 #
-# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
-# 
-check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
-print(f"Check value is: {check_value}")
-
-if "n1" in str(check_value):
-    drop_node = f"spock node-drop n1 {dbname}"
-    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
-    print(f"Print drop.stdout here: - {drop.stdout}")
-print("*"*100)
-
 # Invoke spock node-create, but don't specify a node name:
 
 command = f"spock node-create n1 {dbname}"

--- a/t/spock_node_create_no_node_name.py
+++ b/t/spock_node_create_no_node_name.py
@@ -19,17 +19,6 @@ repuser=os.getenv("EDGE_REPUSER","repuser")
 repset=os.getenv("EDGE_REPSET","demo-repset")
 spockpath=os.getenv("EDGE_SPOCK_PATH")
 dbname=os.getenv("EDGE_DB","lcdb")
-#
-# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
-# 
-check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
-print(f"Check value is: {check_value}")
-
-if "n1" in str(check_value):
-    drop_node = f"spock node-drop n1 {dbname}"
-    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
-    print(f"Print drop.stdout here: - {drop.stdout}")
-print("*"*100)
 
 # Invoke spock node-create, but don't specify a node name:
 

--- a/t/spock_node_create_no_repset_user.py
+++ b/t/spock_node_create_no_repset_user.py
@@ -20,17 +20,6 @@ repset=os.getenv("EDGE_REPSET","demo-repset")
 spockpath=os.getenv("EDGE_SPOCK_PATH")
 dbname=os.getenv("EDGE_DB","lcdb")
 #
-# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
-# 
-check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
-print(f"Check value is: {check_value}")
-
-if "n1" in str(check_value):
-    drop_node = f"spock node-drop n1 {dbname}"
-    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
-    print(f"Print drop.stdout here: - {drop.stdout}")
-print("*"*100)
-
 # Invoke spock node-create, but don't specify a node name:
 
 command = f"spock node-create n1 'host={host} user={usr} dbname={dbname}' {dbname}"


### PR DESCRIPTION
The code I pulled from these cases removed a pre-existing n1 node; when we added the default repset (IIRC) the way nodes/subscriptions are handled changed as well, so in the long schedule the cleanup step fails because of an associated subscription.  Because of that change, the test cases all return an error too early - they need to error because of passed parameters, and not because n1 already exists.